### PR TITLE
Update globs.md for excludes syntax

### DIFF
--- a/src/docs/common_tasks/globs.md
+++ b/src/docs/common_tasks/globs.md
@@ -28,7 +28,7 @@ You can also exclude files from a particular directory:
 
     ::python
     scala_library(name='scala',
-      sources=rglobs('*.scala') - rglobs('dir_to_exclude/*.scala')
+      sources=rglobs('*.scala', exclude=[rglobs('dir_to_exclude/*.scala')]),
     )
 
 ## See Also


### PR DESCRIPTION
### Problem

`globs.md` was explaining globs using the outdated subtraction-based excludes.

### Solution

Use the `exclude` syntax.