### PR TITLE
Possible Double Free Issue in Mir May Compromise Exception Safety in This Crate

### DIFF
--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -676,8 +676,7 @@ pub fn with_vec<F, C, T>(c_ptr: *mut C, c_len: usize, f: F) -> T
 where
   F: FnOnce(&Vec<C>) -> T,
 {
-  let cs = unsafe { Vec::from_raw_parts(c_ptr, c_len, c_len) };
+  let cs = std::mem::ManuallyDrop::new(unsafe { Vec::from_raw_parts(c_ptr, c_len, c_len) });
   let output = f(&cs);
-  mem::forget(cs);
   output
 }

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -879,9 +879,8 @@ fn with_scheduler<F, T>(scheduler_ptr: *mut Scheduler, f: F) -> T
 where
   F: FnOnce(&Scheduler) -> T,
 {
-  let scheduler = unsafe { Box::from_raw(scheduler_ptr) };
+  let scheduler = std::mem::ManuallyDrop::new(unsafe { Box::from_raw(scheduler_ptr) });
   let t = f(&scheduler);
-  mem::forget(scheduler);
   t
 }
 
@@ -892,9 +891,8 @@ fn with_session<F, T>(session_ptr: *mut Session, f: F) -> T
 where
   F: FnOnce(&Session) -> T,
 {
-  let session = unsafe { Box::from_raw(session_ptr) };
+  let session = std::mem::ManuallyDrop::new(unsafe { Box::from_raw(session_ptr) });
   let t = f(&session);
-  mem::forget(session);
   t
 }
 
@@ -905,9 +903,8 @@ fn with_execution_request<F, T>(execution_request_ptr: *mut ExecutionRequest, f:
 where
   F: FnOnce(&mut ExecutionRequest) -> T,
 {
-  let mut execution_request = unsafe { Box::from_raw(execution_request_ptr) };
+  let mut execution_request = std::mem::ManuallyDrop::new(unsafe { Box::from_raw(execution_request_ptr) });
   let t = f(&mut execution_request);
-  mem::forget(execution_request);
   t
 }
 
@@ -918,8 +915,7 @@ fn with_tasks<F, T>(tasks_ptr: *mut Tasks, f: F) -> T
 where
   F: FnOnce(&mut Tasks) -> T,
 {
-  let mut tasks = unsafe { Box::from_raw(tasks_ptr) };
+  let mut tasks = std::mem::ManuallyDrop::new(unsafe { Box::from_raw(tasks_ptr) });
   let t = f(&mut tasks);
-  mem::forget(tasks);
   t
 }


### PR DESCRIPTION
Hi,
I detect several potential double free bugs were detected in your crate via static analysis. This PR contains fixes.

https://github.com/twitter/pants/blob/ebf57169e53ca4ee3696149057bb2c98eb9a86b9/src/rust/engine/src/lib.rs#L882-L884
https://github.com/twitter/pants/blob/ebf57169e53ca4ee3696149057bb2c98eb9a86b9/src/rust/engine/src/lib.rs#L895-L897
https://github.com/twitter/pants/blob/ebf57169e53ca4ee3696149057bb2c98eb9a86b9/src/rust/engine/src/lib.rs#L908-L910
https://github.com/twitter/pants/blob/ebf57169e53ca4ee3696149057bb2c98eb9a86b9/src/rust/engine/src/lib.rs#L921-L923

These bugs primarily emerge when specific functions unwind, predominantly due to the interplay between `Box::from_raw` and `mem::forget`. In Rust MIR (Mid-level Intermediate Representation), inserting code between `Box::from_raw` and `mem::forget` can compromise exception safety. This is because when these pieces of code unwind, both the Box that was created and the entity to which the pointer refers will be dropped. This scenario, in effect, results in a "double free" situation.



https://github.com/twitter/pants/blob/ebf57169e53ca4ee3696149057bb2c98eb9a86b9/src/rust/engine/src/externs.rs#L679-L681

In the second case we shouldn't use code pieces between `Vec::from_raw_parts` and `mem::forget`. Because when these codes unwind, the Vec generated will drop as well as the entity which ptr pointed to. This code block can fix it by using `mem::ManuallyDrop` instead of `mem::forget`.  